### PR TITLE
zPosition of button corrected

### DIFF
--- a/DTZFloatingActionButton/Classes/DTZFloatingActionButton.swift
+++ b/DTZFloatingActionButton/Classes/DTZFloatingActionButton.swift
@@ -140,6 +140,7 @@ open class DTZFloatingActionButton: UIView {
         circleLayer.frame = CGRect(x: 0, y: 0, width: size, height: size)
         circleLayer.backgroundColor = buttonColor.cgColor
         circleLayer.cornerRadius = size / 2
+        layer.zPosition = 1
         layer.addSublayer(circleLayer)
     }
     


### PR DESCRIPTION
Tables with limited amount of cells display the button behind the cell
separators. Stating the zPosition of the circleLayer ensures that the
button appears above the cell separators regardless of the amount of
cells.

**Image displaying 0 cells resulting in button appearing underneath the cell separators.**
![simulator screen shot 28 jun 2017 17 39 17](https://user-images.githubusercontent.com/521678/27649165-e3c91052-5c28-11e7-8777-51cac44f77bf.png)

**Image displaying 0 cells resulting in button appearing above the cell separators.**
![simulator screen shot 28 jun 2017 17 44 11](https://user-images.githubusercontent.com/521678/27649359-74495b50-5c29-11e7-8e35-1e7272db642f.png)



